### PR TITLE
Adds macro with-clipboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ A Clojure library for easy interop with the system clipboard.
 (clipboard/spit "Hello, World")
 
 (clipboard/spit-html "<strong>Hello</strong>, <em>World</em>")
+
+(clipboard/with-clipboard (println "Hello There!"))
 ```
 
 ## License

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject org.exupero/clipboard "0.1.0"
+(defproject org.exupero/clipboard "0.2.0"
   :description "Clojure interop with system clipboard"
   :url "https://github.com/exupero/clipboard"
   :license {:name "Eclipse Public License"

--- a/src/clipboard/core.clj
+++ b/src/clipboard/core.clj
@@ -1,6 +1,7 @@
 (ns clipboard.core
   (:refer-clojure :exclude [slurp spit])
-  (:import [java.awt.datatransfer DataFlavor StringSelection Transferable]))
+  (:import [java.awt.datatransfer DataFlavor StringSelection Transferable]
+           [java.awt Toolkit]))
 
 (defn clipboard []
   (.getSystemClipboard (java.awt.Toolkit/getDefaultToolkit)))
@@ -37,3 +38,12 @@
 
 (defn spit-html [html]
   (.setContents (clipboard) (HtmlSelection. html) nil))
+
+(defmacro with-clipboard [& body]
+  `(binding [*out* (java.io.StringWriter.)]
+     (let [result# (do ~@body)]
+       (.. Toolkit
+           (getDefaultToolkit)
+           (getSystemClipboard)
+           (setContents (StringSelection. (str *out*)) nil))
+       result#)))


### PR DESCRIPTION
This allows a user to deliver any stdout in the macro's body straight to
the clipboard.
Taken from a stackoverflow answer:
https://stackoverflow.com/questions/38486269/copy-result-from-leiningen-repl-into-clipboard